### PR TITLE
[feat-ctr-controller] CTR Model Predictor 컨트롤러 단에 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 .idea/
-
+ctr_model.npy
 # C extensions
 *.so
 .idea/

--- a/trAIner/app/__init__.py
+++ b/trAIner/app/__init__.py
@@ -10,6 +10,7 @@ from app.api.template import template as template_bp
 from app.api.error_handler import error_handler as error_bp
 from app.api.v1 import api_v1 as api_v1_bp
 from model import register_connection_pool
+from controller.ctr_predictor import CTRPredictor
 
 
 class CustomJSONEncoder(JSONEncoder):
@@ -38,6 +39,9 @@ def create_flask_app(config):
     register_connection_pool(app)
 
     # Model Controller import
+    app.ctr_predictor = CTRPredictor(
+        config.CTR_MODEL_PATH
+    )
 
     app.register_blueprint(error_bp)
     app.register_blueprint(template_bp)

--- a/trAIner/app/__init__.py
+++ b/trAIner/app/__init__.py
@@ -37,9 +37,11 @@ def create_flask_app(config):
     api.init_app(app)
     register_connection_pool(app)
 
+    # Model Controller import
+
     app.register_blueprint(error_bp)
     app.register_blueprint(template_bp)
-    app.register_blueprint(sample_v1_bp, url_prefix='/api/v1')
+    app.register_blueprint(api_v1_bp, url_prefix='/api/v1')
 
     return app
 

--- a/trAIner/app/api/v1/calculator.py
+++ b/trAIner/app/api/v1/calculator.py
@@ -5,7 +5,7 @@ from flask import abort
 from flask_validation_extended import Validator, Query
 from flask_validation_extended import ValidationRule
 from app.api.response import response_200, bad_request
-from app.api.sample_api import sample_api as api
+from app.api.v1 import api_v1 as api
 from app.api.decorator import timer
 from controller import calculator, log
 

--- a/trAIner/app/api/v1/info.py
+++ b/trAIner/app/api/v1/info.py
@@ -4,7 +4,7 @@ Get API
 from flask import g, jsonify, current_app
 from flask_validation_extended import Json, Validator
 from app.api.response import response_200, bad_request, created
-from app.api.sample_api import sample_api as api
+from app.api.v1 import api_v1 as api
 from app.api.decorator import timer
 from model.mongodb import MasterConfig, Log
 

--- a/trAIner/config.py
+++ b/trAIner/config.py
@@ -23,6 +23,9 @@ class Config:
     # API 타이머 출력 경로 (response, log, none)
     TIMER_OUTPUT = 'response'
 
+    # Model Paths
+    CTR_MODEL_PATH = os.environ['CTR_MODEL_PATH']
+
     @staticmethod
     def init_app(app):
         pass

--- a/trAIner/controller/ctr_predictor.py
+++ b/trAIner/controller/ctr_predictor.py
@@ -1,0 +1,59 @@
+import numpy as np
+from controller.exceptions import (
+	UserIndexError, ItemIndexError
+)
+
+class CTRPredictor:
+
+	def __init__(self, ctr_model_path: str):
+		self.ctr_model_path = ctr_model_path
+		self.pred_matrix = np.load(ctr_model_path)
+
+	def predict(self, user_id: int, item_id: int):
+		y_pred = self.predict_probe(user_id, item_id)
+		y_pred = True if y_pred >= 3 else False
+		return y_pred
+
+	def predict_probe(self, user_id: int, item_id: int):
+
+		if not (0 <= user_id <= 1002):
+			raise UserIndexError()
+		if not (0 <= item_id <= 1187):
+			raise ItemIndexError()
+
+		y_pred = self.pred_matrix[item_id, user_id]
+		return y_pred
+
+
+if __name__ == '__main__':
+	from config import config
+
+	predictor = CTRPredictor(config.CTR_MODEL_PATH)
+
+	# Normal Case
+	user_id, item_id = 569, 586
+	print(
+		f"User({user_id})의 Item({item_id})의 클릭 여부:", 
+		predictor.predict(user_id, item_id)
+	)
+	# 3보다 높으면 True, 낮으면 False
+	print(
+		f"User({user_id})의 Item({item_id})의 Probe Value:", 
+		predictor.predict_probe(user_id, item_id)
+	)
+
+	# Error Case
+	try:
+		user_id, item_id = 99999, 0
+		predictor.predict(user_id, item_id)
+	except UserIndexError:
+		print("UserIndexError 발생.")
+	
+	try:
+		user_id, item_id = 0, 99999
+		predictor.predict(user_id, item_id)
+	except ItemIndexError:
+		print("ItemIndexError 발생.")
+
+
+

--- a/trAIner/controller/exceptions.py
+++ b/trAIner/controller/exceptions.py
@@ -1,0 +1,11 @@
+
+
+
+class UserIndexError(Exception):
+	def __str__(self):
+		return "User Index 범위를 초과함."
+
+
+class ItemIndexError(Exception):
+	def __str__(self):
+		return "Item(Problem) Index 범위를 초과함."

--- a/trAIner/requirements.txt
+++ b/trAIner/requirements.txt
@@ -8,6 +8,7 @@ importlib-metadata==4.12.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.1
+numpy==1.23.4
 PyJWT==2.6.0
 pymongo==4.3.2
 python-dateutil==2.8.2


### PR DESCRIPTION
- 모델을 가져와서 CTRPredictor에서 불러와 예측할 수 있도록 구현
- hot user / item 외의 다른 인덱스가 입력될 경우 에러가 반환됨 (주의)
- app 초기화시 전역에서 사용할 수 있도록 app 내부 변수 내에 초기화 되도록 작성.
- ctr model path를 가리키기 위한 `CTR_MODEL_PATH` 환경 변수 추가.

자세한 사용법은 Class 선언부에 함께 작성된 테스트 코드 확인해보면 좋을듯.
close #9 